### PR TITLE
Fixes #1. Update sample dewpoint calculator app.

### DIFF
--- a/src/dewpointcalc/dewpoint.go
+++ b/src/dewpointcalc/dewpoint.go
@@ -36,7 +36,7 @@ type Config struct {
 }
 
 func main() {
-	if err := qml.Run(run); err != nil {
+	if err := qml.SailfishRun(run); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -115,18 +115,18 @@ func run() error {
 	//dewpoint.Root.ObjectByName("humidityslider").Set("value", config.HumOnClose)
 	dewpoint.Lastcalctime = config.LastRun
 
-	engine := qml.NewEngine()
+	engine := qml.SailfishNewEngine()
 	engine.Translator("/usr/share/harbour-dewpointcalc/qml/i18n")
 
 	//dewpoint := DewpointControl{Dewpoint: "", Humidity: "", Temperature: ""}
 	context := engine.Context()
 	context.SetVar("dewpointctrl", &dewpoint)
-	controls, err := engine.LoadFile("/usr/share/harbour-dewpointcalc/qml/main.qml")
+	controls, err := engine.SailfishSetSource("qml/main.qml")
 	if err != nil {
 		return err
 	}
 
-	window := controls.CreateWindow(nil)
+	window := controls.SailfishCreateWindow()
 	dewpoint.Root = window.Root()
 
 	err = loadSettings()
@@ -146,7 +146,7 @@ func run() error {
 	dewpoint.Root.ObjectByName("tempslider").Set("value", config.TempOnClose)
 	dewpoint.Root.ObjectByName("humidityslider").Set("value", config.HumOnClose)
 	//dewpoint.Lastcalctime = config.LastRun
-	window.Show()
+	window.SailfishShow()
 	window.Wait()
 
 	config.TempOnClose = dewpoint.temp

--- a/src/dewpointcalc/dewpointcalc.desktop
+++ b/src/dewpointcalc/dewpointcalc.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Version=1.0
 Type=Application
-X-Nemo-Application-Type=no-invoker
+X-Nemo-Application-Type=generic
 Name=Dewpoint calculator
 Icon=harbour-dewpointcalc
 Exec=harbour-dewpointcalc

--- a/src/dewpointcalc/dewpointcalc.desktop
+++ b/src/dewpointcalc/dewpointcalc.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Version=1.0
 Type=Application
-X-Nemo-Application-Type=generic
+X-Nemo-Application-Type=no-invoker
 Name=Dewpoint calculator
 Icon=harbour-dewpointcalc
 Exec=harbour-dewpointcalc


### PR DESCRIPTION
First, thanks for the great work! I believe this should fix the sample dewpoint calculator app from crashing as reported in issue #1. I tested this using SailfishOSSDK-Beta-1511-Qt5-linux-64 and is working great. Here's a summary:

The dewpoint calculator app was crashing with this error:

  qwaylandglcontext.cpp:386: QWaylandGLContext::makeCurrent: eglError: 3009, this: 0x8e97d08

This commit fixes the crash by using the qml.SailfishRun() methods to
launch the SailfishApp:: instance, per this thread:

 https://together.jolla.com/question/105098/how-to-setup-go-142-runtime-and-go-qml-pkg-for-mersdk/

Also found that X-Nemo-Application-Type=generic did not work and never
launced the app. Instead setting this to
X-Nemo-Application-Type=no-invoker fixed the problem.
